### PR TITLE
Allow arbitrary eigen include dir location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ ext_modules = [
         ],
         language="C++",
         include_dirs=[
-            "/usr/include/eigen3/",
+            os.environ.get("EIGEN_INCLUDE_DIR", "/usr/include/eigen3/"),
             # Path to pybind11 headers
             get_pybind_include(),
             get_pybind_include(user=True),


### PR DESCRIPTION
Until now, the include directory of eigen was hardcoded in `setup.py`. This is not a problem when users install `pygalmesh` and its dependencies on a system where they have root access.

When trying to install it on a cluster or using a non root user (where eigen is not installed under `/usr`), using `python3 -m pip install pygalmesh` issued the following error:
```
ERROR: Command errored out with exit status 1:
     command: /home/ulg/crc/mgrgnrd/.local/python-3.7.3/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0_tx2nih/pygalmesh/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0_tx2nih/pygalmesh/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-3vq2jezz/install-record.txt --single-version-externally-managed --compile
         cwd: /tmp/pip-install-0_tx2nih/pygalmesh/
    Complete output (22 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.7
    creating build/lib.linux-x86_64-3.7/pygalmesh
    copying pygalmesh/main.py -> build/lib.linux-x86_64-3.7/pygalmesh
    copying pygalmesh/__init__.py -> build/lib.linux-x86_64-3.7/pygalmesh
    copying pygalmesh/__about__.py -> build/lib.linux-x86_64-3.7/pygalmesh
    copying pygalmesh/cli.py -> build/lib.linux-x86_64-3.7/pygalmesh
    running build_ext
    building '_pygalmesh' extension
    creating build/temp.linux-x86_64-3.7
    creating build/temp.linux-x86_64-3.7/src
    gcc -pthread -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/include/eigen3/ -I/home/ulg/crc/mgrgnrd/.local/python-3.7.3/include/python3.7m -I/home/ulg/crc/mgrgnrd/.local/include/python3.7m -I/home/ulg/crc/mgrgnrd/.local/python-3.7.3/include/python3.7m -c src/generate.cpp -o build/temp.linux-x86_64-3.7/src/generate.o
    In file included from src/generate.hpp:4,
                     from src/generate.cpp:3:
    src/domain.hpp:4:10: fatal error: Eigen/Dense: No such file or directory
        4 | #include <Eigen/Dense>
          |          ^~~~~~~~~~~~~
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /home/ulg/crc/mgrgnrd/.local/python-3.7.3/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0_tx2nih/pygalmesh/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0_tx2nih/pygalmesh/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-3vq2jezz/install-record.txt --single-version-externally-managed --compile Check the logs for full command output.
```

Allowing the user to set `EIGEN_INCLUDE_DIR` in his environment could help broaden the systems on which users could use this package. The installation process would become:
```shell
export EIGEN_INCLUDE_DIR=/path/to/include/eigen3
python3 -m pip install pygalmesh
```

I hope this solution will work. It would be very helpful as it would not require the user to install `pygalmesh` from `setup.py` meaning it would allow future upgrades or uninstall.