### PR TITLE
Specify subdomain cell size and meshing from numpy array geometries

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,42 @@ mesh = pygalmesh.generate_from_inr(
 )
 ```
 
+## Meshes from numpy array representing 3D images
+<img src="https://nschloe.github.io/pygalmesh/phantom.png" width="30%">
+
+pygalmesh can help generating unstructed meshes from 3D numpy arrays.
+
+The code below creates a mesh from the 3D breast phantom from [Lou et al](http://biomedicaloptics.spiedigitallibrary.org/article.aspx?articleid=2600985) available [here](https://wustl.app.box.com/s/rqivtin0xcofjwlkz43acou8jknsbfx8/file/127108205145).
+The phantom comprises four tissue types (background, fat, fibrograndular, skin, vascular tissues). The generated mesh conforms to tissues interfaces.
+
+```python
+import pygalmesh
+import meshio
+
+Nx = 722
+Ny = 411
+Nz = 284
+h = [0.2]*3
+    
+with open('MergedPhantom.DAT', 'rb') as fid:
+    vol = np.fromfile(fid, dtype=np.uint8)
+
+vol = vol.reshape((Nx,Ny,Nz))
+
+       
+mesh = pygalmesh.generate_from_array(vol, h, facet_distance=.2, cell_size=1.)
+meshio.write('breast.vtk',mesh)
+```
+
+In addition, we can specify different mesh sizes for each tissue type. The code below sets the mesh size to  *1 mm* for the skin tissue (label `4`), *0.5 mm* for the vascular tissue (label `5`), and *2 mm* for all other tissues (`default`).
+
+```python
+cell_sizes_map = {'default': 2., 4: 1., 5: .5}
+mesh = pygalmesh.generate_from_array_with_subdomain_sizing(
+           vol, h, facet_distance=.2, cell_sizes_map=cell_sizes_map)
+meshio.write('breast_adapted.vtk',mesh)
+```
+
 #### Surface remeshing
 <img src="https://nschloe.github.io/pygalmesh/lion-head.png" width="30%">
 

--- a/pygalmesh/__init__.py
+++ b/pygalmesh/__init__.py
@@ -71,5 +71,5 @@ __all__ = [
     "generate_from_inr",
     "generate_from_inr_with_subdomain_sizing",
     "remesh_surface",
-    "saveinr"
+    "saveinr",
 ]

--- a/pygalmesh/__init__.py
+++ b/pygalmesh/__init__.py
@@ -24,17 +24,17 @@ from _pygalmesh import (
 
 from .__about__ import __version__
 from .main import (
-    generate_from_inr,
-    generate_from_inr_with_subdomain_sizing,
     generate_from_array,
     generate_from_array_with_subdomain_sizing,
+    generate_from_inr,
+    generate_from_inr_with_subdomain_sizing,
     generate_mesh,
     generate_periodic_mesh,
     generate_surface_mesh,
     generate_volume_mesh_from_surface_mesh,
     generate_with_sizing_field,
     remesh_surface,
-    saveinr
+    saveinr,
 )
 
 __all__ = [

--- a/pygalmesh/__init__.py
+++ b/pygalmesh/__init__.py
@@ -66,6 +66,10 @@ __all__ = [
     "generate_periodic_mesh",
     "generate_surface_mesh",
     "generate_volume_mesh_from_surface_mesh",
+    "generate_from_array",
+    "generate_from_array_with_subdomain_sizing",
     "generate_from_inr",
+    "generate_from_inr_with_subdomain_sizing",
     "remesh_surface",
+    "saveinr"
 ]

--- a/pygalmesh/__init__.py
+++ b/pygalmesh/__init__.py
@@ -25,12 +25,16 @@ from _pygalmesh import (
 from .__about__ import __version__
 from .main import (
     generate_from_inr,
+    generate_from_inr_with_subdomain_sizing,
+    generate_from_array,
+    generate_from_array_with_subdomain_sizing,
     generate_mesh,
     generate_periodic_mesh,
     generate_surface_mesh,
     generate_volume_mesh_from_surface_mesh,
     generate_with_sizing_field,
     remesh_surface,
+    saveinr
 )
 
 __all__ = [

--- a/pygalmesh/main.py
+++ b/pygalmesh/main.py
@@ -254,6 +254,7 @@ def generate_from_inr(
     os.remove(outfile)
     return mesh
 
+
 def generate_from_inr_with_subdomain_sizing(
     inr_filename,
     cell_sizes_map,
@@ -270,14 +271,14 @@ def generate_from_inr_with_subdomain_sizing(
 ):
     fh, outfile = tempfile.mkstemp(suffix=".mesh")
     os.close(fh)
-    
+
     if "default" in cell_sizes_map.keys():
         default_cell_size = cell_sizes_map.pop("default")
     else:
-        default_cell_size = 0.
-    
-    cell_sizes  = [cell_sizes_map[k] for k in cell_sizes_map.keys() ]
-    subdomain_labels = list( cell_sizes_map.keys() )
+        default_cell_size = 0.0
+
+    cell_sizes = [cell_sizes_map[k] for k in cell_sizes_map.keys()]
+    subdomain_labels = list(cell_sizes_map.keys())
 
     _generate_from_inr_with_subdomain_sizing(
         inr_filename,
@@ -300,6 +301,7 @@ def generate_from_inr_with_subdomain_sizing(
     mesh = meshio.read(outfile)
     os.remove(outfile)
     return mesh
+
 
 def remesh_surface(
     filename,
@@ -333,6 +335,7 @@ def remesh_surface(
     os.remove(outfile)
     return mesh
 
+
 def saveinr(vol, h, fname):
     """
     Save a volume (described as a numpy array) to INR format.
@@ -342,33 +345,36 @@ def saveinr(vol, h, fname):
     - h: voxel sizes as list or numpy array
     - fname: filename for saving the inr file
     """
-    
-    fid = open(fname, 'wb')
+
+    fid = open(fname, "wb")
     vol_type = vol.dtype
-    
-    if vol_type=='uint8':
-        btype='unsigned fixed'
-        bitlen=8
-    elif vol_type=='uint16':
-        btype='unsigned fixed'
-        bitlen=16
-    elif vol_type=='float32':
-        btype='float'
-        bitlen=32
-    elif vol_type=='float64':
-        btype='float'
-        bitlen=64
+
+    if vol_type == "uint8":
+        btype = "unsigned fixed"
+        bitlen = 8
+    elif vol_type == "uint16":
+        btype = "unsigned fixed"
+        bitlen = 16
+    elif vol_type == "float32":
+        btype = "float"
+        bitlen = 32
+    elif vol_type == "float64":
+        btype = "float"
+        bitlen = 64
     else:
-        raise(vol_type)
-    
-    header = ('#INRIMAGE-4#{8:s}\nXDIM={0:d}\nYDIM={1:d}\nZDIM={2:d}\nVDIM=1\nTYPE={3:s}\n' +
-              'PIXSIZE={4:d} bits\nCPU=decm\nVX={5:f}\nVY={6:f}\nVZ={7:f}\n').format(*vol.shape, btype, bitlen, h[0], h[1], h[2], '{')
-              
-    header = header+ '\n'*(256-4-len(header))+'##}\n'
-    
-    fid.write(header.encode('ascii'))
-    fid.write(vol.tobytes(order='F'))
-    
+        raise (vol_type)
+
+    header = (
+        "#INRIMAGE-4#{8:s}\nXDIM={0:d}\nYDIM={1:d}\nZDIM={2:d}\nVDIM=1\nTYPE={3:s}\n"
+        + "PIXSIZE={4:d} bits\nCPU=decm\nVX={5:f}\nVY={6:f}\nVZ={7:f}\n"
+    ).format(*vol.shape, btype, bitlen, h[0], h[1], h[2], "{")
+
+    header = header + "\n" * (256 - 4 - len(header)) + "##}\n"
+
+    fid.write(header.encode("ascii"))
+    fid.write(vol.tobytes(order="F"))
+
+
 def generate_from_array(
     vol,
     h,
@@ -387,11 +393,23 @@ def generate_from_array(
     fh, inr_filename = tempfile.mkstemp(suffix=".inr")
     os.close(fh)
     saveinr(vol, h, inr_filename)
-    mesh = generate_from_inr(inr_filename, lloyd, odt, perturb, exude,
-                    edge_size, facet_angle, facet_size, facet_distance,
-                    cell_radius_edge_ratio, cell_size, verbose)
+    mesh = generate_from_inr(
+        inr_filename,
+        lloyd,
+        odt,
+        perturb,
+        exude,
+        edge_size,
+        facet_angle,
+        facet_size,
+        facet_distance,
+        cell_radius_edge_ratio,
+        cell_size,
+        verbose,
+    )
     os.remove(inr_filename)
     return mesh
+
 
 def generate_from_array_with_subdomain_sizing(
     vol,
@@ -408,14 +426,23 @@ def generate_from_array_with_subdomain_sizing(
     cell_radius_edge_ratio=0.0,
     verbose=True,
 ):
-    assert vol.dtype in ['uint8', 'uint16']
+    assert vol.dtype in ["uint8", "uint16"]
     fh, inr_filename = tempfile.mkstemp(suffix=".inr")
     os.close(fh)
     saveinr(vol, h, inr_filename)
     mesh = generate_from_inr_with_subdomain_sizing(
-                    inr_filename, cell_sizes_map,
-                    lloyd, odt, perturb, exude,
-                    edge_size, facet_angle, facet_size, facet_distance,
-                    cell_radius_edge_ratio, verbose)
+        inr_filename,
+        cell_sizes_map,
+        lloyd,
+        odt,
+        perturb,
+        exude,
+        edge_size,
+        facet_angle,
+        facet_size,
+        facet_distance,
+        cell_radius_edge_ratio,
+        verbose,
+    )
     os.remove(inr_filename)
     return mesh

--- a/pygalmesh/main.py
+++ b/pygalmesh/main.py
@@ -4,6 +4,7 @@ import tempfile
 import meshio
 from _pygalmesh import (
     _generate_from_inr,
+    _generate_from_inr_with_subdomain_sizing,
     _generate_from_off,
     _generate_mesh,
     _generate_periodic_mesh,
@@ -253,6 +254,52 @@ def generate_from_inr(
     os.remove(outfile)
     return mesh
 
+def generate_from_inr_with_subdomain_sizing(
+    inr_filename,
+    cell_sizes_map,
+    lloyd=False,
+    odt=False,
+    perturb=True,
+    exude=True,
+    edge_size=0.0,
+    facet_angle=0.0,
+    facet_size=0.0,
+    facet_distance=0.0,
+    cell_radius_edge_ratio=0.0,
+    verbose=True,
+):
+    fh, outfile = tempfile.mkstemp(suffix=".mesh")
+    os.close(fh)
+    
+    if "default" in cell_sizes_map.keys():
+        default_cell_size = cell_sizes_map.pop("default")
+    else:
+        default_cell_size = 0.
+    
+    cell_sizes  = [cell_sizes_map[k] for k in cell_sizes_map.keys() ]
+    subdomain_labels = list( cell_sizes_map.keys() )
+
+    _generate_from_inr_with_subdomain_sizing(
+        inr_filename,
+        outfile,
+        default_cell_size,
+        cell_sizes,
+        subdomain_labels,
+        lloyd=lloyd,
+        odt=odt,
+        perturb=perturb,
+        exude=exude,
+        edge_size=edge_size,
+        facet_angle=facet_angle,
+        facet_size=facet_size,
+        facet_distance=facet_distance,
+        cell_radius_edge_ratio=cell_radius_edge_ratio,
+        verbose=verbose,
+    )
+
+    mesh = meshio.read(outfile)
+    os.remove(outfile)
+    return mesh
 
 def remesh_surface(
     filename,
@@ -284,4 +331,91 @@ def remesh_surface(
     mesh = meshio.read(outfile)
     os.remove(off_file)
     os.remove(outfile)
+    return mesh
+
+def saveinr(vol, h, fname):
+    """
+    Save a volume (described as a numpy array) to INR format.
+    Code inspired by iso2mesh (http://iso2mesh.sf.net) by Q. Fang
+    INPUTS:
+    - vol: volume as numpy array
+    - h: voxel sizes as list or numpy array
+    - fname: filename for saving the inr file
+    """
+    
+    fid = open(fname, 'wb')
+    vol_type = vol.dtype
+    
+    if vol_type=='uint8':
+        btype='unsigned fixed'
+        bitlen=8
+    elif vol_type=='uint16':
+        btype='unsigned fixed'
+        bitlen=16
+    elif vol_type=='float32':
+        btype='float'
+        bitlen=32
+    elif vol_type=='float64':
+        btype='float'
+        bitlen=64
+    else:
+        raise(vol_type)
+    
+    header = ('#INRIMAGE-4#{8:s}\nXDIM={0:d}\nYDIM={1:d}\nZDIM={2:d}\nVDIM=1\nTYPE={3:s}\n' +
+              'PIXSIZE={4:d} bits\nCPU=decm\nVX={5:f}\nVY={6:f}\nVZ={7:f}\n').format(*vol.shape, btype, bitlen, h[0], h[1], h[2], '{')
+              
+    header = header+ '\n'*(256-4-len(header))+'##}\n'
+    
+    fid.write(header.encode('ascii'))
+    fid.write(vol.tobytes(order='F'))
+    
+def generate_from_array(
+    vol,
+    h,
+    lloyd=False,
+    odt=False,
+    perturb=True,
+    exude=True,
+    edge_size=0.0,
+    facet_angle=0.0,
+    facet_size=0.0,
+    facet_distance=0.0,
+    cell_radius_edge_ratio=0.0,
+    cell_size=0.0,
+    verbose=True,
+):
+    fh, inr_filename = tempfile.mkstemp(suffix=".inr")
+    os.close(fh)
+    saveinr(vol, h, inr_filename)
+    mesh = generate_from_inr(inr_filename, lloyd, odt, perturb, exude,
+                    edge_size, facet_angle, facet_size, facet_distance,
+                    cell_radius_edge_ratio, cell_size, verbose)
+    os.remove(inr_filename)
+    return mesh
+
+def generate_from_array_with_subdomain_sizing(
+    vol,
+    h,
+    cell_sizes_map,
+    lloyd=False,
+    odt=False,
+    perturb=True,
+    exude=True,
+    edge_size=0.0,
+    facet_angle=0.0,
+    facet_size=0.0,
+    facet_distance=0.0,
+    cell_radius_edge_ratio=0.0,
+    verbose=True,
+):
+    assert vol.dtype in ['uint8', 'uint16']
+    fh, inr_filename = tempfile.mkstemp(suffix=".inr")
+    os.close(fh)
+    saveinr(vol, h, inr_filename)
+    mesh = generate_from_inr_with_subdomain_sizing(
+                    inr_filename, cell_sizes_map,
+                    lloyd, odt, perturb, exude,
+                    edge_size, facet_angle, facet_size, facet_distance,
+                    cell_radius_edge_ratio, verbose)
+    os.remove(inr_filename)
     return mesh

--- a/src/generate_from_inr.cpp
+++ b/src/generate_from_inr.cpp
@@ -30,6 +30,9 @@ typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
 typedef Mesh_criteria::Facet_criteria Facet_criteria;
 typedef Mesh_criteria::Cell_criteria Cell_criteria;
 
+typedef CGAL::Mesh_constant_domain_field_3<Mesh_domain::R,
+                                           Mesh_domain::Index> Sizing_field_cell;
+
 void
 generate_from_inr(
     const std::string & inr_filename,
@@ -53,6 +56,71 @@ generate_from_inr(
     throw "Could not read image file";
   }
   Mesh_domain cgal_domain = Mesh_domain::create_labeled_image_mesh_domain(image);
+
+  Mesh_criteria criteria(
+      CGAL::parameters::edge_size=edge_size,
+      CGAL::parameters::facet_angle=facet_angle,
+      CGAL::parameters::facet_size=facet_size,
+      CGAL::parameters::facet_distance=facet_distance,
+      CGAL::parameters::cell_radius_edge_ratio=cell_radius_edge_ratio,
+      CGAL::parameters::cell_size=cell_size
+      );
+
+  // Mesh generation
+  if (!verbose) {
+    // suppress output
+    std::cerr.setstate(std::ios_base::failbit);
+  }
+  C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(
+      cgal_domain,
+      criteria,
+      lloyd ? CGAL::parameters::lloyd() : CGAL::parameters::no_lloyd(),
+      odt ? CGAL::parameters::odt() : CGAL::parameters::no_odt(),
+      perturb ? CGAL::parameters::perturb() : CGAL::parameters::no_perturb(),
+      exude ? CGAL::parameters::exude() : CGAL::parameters::no_exude()
+      );
+  if (!verbose) {
+    std::cerr.clear();
+  }
+
+  // Output
+  std::ofstream medit_file(outfile);
+  c3t3.output_to_medit(medit_file);
+  medit_file.close();
+  return;
+}
+
+
+void
+generate_from_inr_with_subdomain_sizing(
+    const std::string & inr_filename,
+    const std::string & outfile,
+	const double default_cell_size,
+    const std::vector<double> & cell_sizes,
+	const std::vector<int> & cell_labels,
+    const bool lloyd,
+    const bool odt,
+    const bool perturb,
+    const bool exude,
+    const double edge_size,
+    const double facet_angle,
+    const double facet_size,
+    const double facet_distance,
+    const double cell_radius_edge_ratio,
+    const bool verbose
+    )
+{
+  CGAL::Image_3 image;
+  const bool success = image.read(inr_filename.c_str());
+  if (!success) {
+    throw "Could not read image file";
+  }
+  Mesh_domain cgal_domain = Mesh_domain::create_labeled_image_mesh_domain(image);
+
+  Sizing_field_cell cell_size(default_cell_size);
+  const int ndimensions = 3;
+  for(std::vector<double>::size_type i(0); i < cell_sizes.size(); ++i)
+	  cell_size.set_size(cell_sizes[i], ndimensions, cgal_domain.index_from_subdomain_index(cell_labels[i]));
 
   Mesh_criteria criteria(
       CGAL::parameters::edge_size=edge_size,

--- a/src/generate_from_inr.hpp
+++ b/src/generate_from_inr.hpp
@@ -22,6 +22,25 @@ void generate_from_inr(
     const bool verbose = true
     );
 
+void
+generate_from_inr_with_subdomain_sizing(
+    const std::string & inr_filename,
+    const std::string & outfile,
+	const double default_cell_size,
+    const std::vector<double> & cell_sizes,
+	const std::vector<int> & cell_labels,
+    const bool lloyd = false,
+    const bool odt = false,
+    const bool perturb  = true,
+    const bool exude = true,
+    const double edge_size = 0.0,
+    const double facet_angle = 0.0,
+    const double facet_size = 0.0,
+    const double facet_distance = 0.0,
+    const double cell_radius_edge_ratio = 0.0,
+    const bool verbose  = true
+    );
+
 } // namespace pygalmesh
 
 #endif // GENERATE_FROM_INR_HPP

--- a/src/pybind11.cpp
+++ b/src/pybind11.cpp
@@ -349,7 +349,25 @@ PYBIND11_MODULE(_pygalmesh, m) {
         py::arg("facet_size") = 0.0,
         py::arg("facet_distance") = 0.0,
         py::arg("cell_radius_edge_ratio") = 0.0,
-        py::arg("cell_size") = 0.0,
+		py::arg("cell_size") = 0.0,
+        py::arg("verbose") = true
+        );
+    m.def(
+        "_generate_from_inr_with_subdomain_sizing", &generate_from_inr_with_subdomain_sizing,
+        py::arg("inr_filename"),
+        py::arg("outfile"),
+        py::arg("default_cell_size"),
+		py::arg("cell_sizes"),
+		py::arg("cell_labels"),
+        py::arg("lloyd") = false,
+        py::arg("odt") = false,
+        py::arg("perturb") = true,
+        py::arg("exude") = true,
+        py::arg("edge_size") = 0.0,
+        py::arg("facet_angle") = 0.0,
+        py::arg("facet_size") = 0.0,
+        py::arg("facet_distance") = 0.0,
+        py::arg("cell_radius_edge_ratio") = 0.0,
         py::arg("verbose") = true
         );
     m.def(

--- a/test/test_from_array.py
+++ b/test/test_from_array.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 
 import helpers

--- a/test/test_from_array.py
+++ b/test/test_from_array.py
@@ -1,69 +1,70 @@
 import os
 
+import numpy as np
+
 import helpers
 import pygalmesh
 
-import numpy as np
-
 
 def test_from_array():
-    
+
     n = 500
-    shape = (n,n,n)
-    h     = [1./s for s in shape]
+    shape = (n, n, n)
+    h = [1.0 / s for s in shape]
     vol = np.zeros(shape, dtype=np.uint16)
     i, j, k = np.arange(shape[0]), np.arange(shape[1]), np.arange(shape[2])
-    ii, jj, kk = np.meshgrid(i,j,k)
-    vol[ii*ii + jj*jj + kk*kk < n**2]        = 1
-    vol[ii*ii + jj*jj + kk*kk < (.5*n)**2]   = 2
-    
+    ii, jj, kk = np.meshgrid(i, j, k)
+    vol[ii * ii + jj * jj + kk * kk < n ** 2] = 1
+    vol[ii * ii + jj * jj + kk * kk < (0.5 * n) ** 2] = 2
+
     mesh = pygalmesh.generate_from_array(
-        vol, h, cell_size=100*min(h), facet_distance=min(h), verbose=False
+        vol, h, cell_size=100 * min(h), facet_distance=min(h), verbose=False
     )
 
     tol = min(h)
-    ref = [1., 0., 1., 0., 1., 0.]
-    assert abs(max(mesh.points[:, 0]) - ref[0]) < tol 
+    ref = [1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
+    assert abs(max(mesh.points[:, 0]) - ref[0]) < tol
     assert abs(min(mesh.points[:, 0]) - ref[1]) < tol
     assert abs(max(mesh.points[:, 1]) - ref[2]) < tol
-    assert abs(min(mesh.points[:, 1]) - ref[3]) < tol 
+    assert abs(min(mesh.points[:, 1]) - ref[3]) < tol
     assert abs(max(mesh.points[:, 2]) - ref[4]) < tol
     assert abs(min(mesh.points[:, 2]) - ref[5]) < tol
 
     vol = sum(helpers.compute_volumes(mesh.points, mesh.get_cells_type("tetra")))
-    ref = 1./6.*np.pi
+    ref = 1.0 / 6.0 * np.pi
     # Debian needs 2.0e-2 here.
     # <https://github.com/nschloe/pygalmesh/issues/60>
     assert abs(vol - ref) < ref * 2.0e-2
-    
+
+
 def test_from_array_with_subdomain_sizing():
-    
+
     n = 500
-    shape = (n,n,n)
-    h     = [1./s for s in shape]
+    shape = (n, n, n)
+    h = [1.0 / s for s in shape]
     vol = np.zeros(shape, dtype=np.uint16)
     i, j, k = np.arange(shape[0]), np.arange(shape[1]), np.arange(shape[2])
-    ii, jj, kk = np.meshgrid(i,j,k)
-    vol[ii*ii + jj*jj + kk*kk < n**2]        = 1
-    vol[ii*ii + jj*jj + kk*kk < (.5*n)**2]   = 2
-    
-    cell_sizes_map = {1: 100*min(h), 2: 10*min(h)}
-    
+    ii, jj, kk = np.meshgrid(i, j, k)
+    vol[ii * ii + jj * jj + kk * kk < n ** 2] = 1
+    vol[ii * ii + jj * jj + kk * kk < (0.5 * n) ** 2] = 2
+
+    cell_sizes_map = {1: 100 * min(h), 2: 10 * min(h)}
+
     mesh = pygalmesh.generate_from_array_with_subdomain_sizing(
         vol, h, cell_sizes_map=cell_sizes_map, facet_distance=min(h), verbose=False
     )
 
     tol = min(h)
-    ref = [1., 0., 1., 0., 1., 0.]
-    assert abs(max(mesh.points[:, 0]) - ref[0]) < tol 
+    ref = [1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
+    assert abs(max(mesh.points[:, 0]) - ref[0]) < tol
     assert abs(min(mesh.points[:, 0]) - ref[1]) < tol
     assert abs(max(mesh.points[:, 1]) - ref[2]) < tol
-    assert abs(min(mesh.points[:, 1]) - ref[3]) < tol 
+    assert abs(min(mesh.points[:, 1]) - ref[3]) < tol
     assert abs(max(mesh.points[:, 2]) - ref[4]) < tol
     assert abs(min(mesh.points[:, 2]) - ref[5]) < tol
 
     vol = sum(helpers.compute_volumes(mesh.points, mesh.get_cells_type("tetra")))
-    ref = 1./6.*np.pi
+    ref = 1.0 / 6.0 * np.pi
     # Debian needs 2.0e-2 here.
     # <https://github.com/nschloe/pygalmesh/issues/60>
     assert abs(vol - ref) < ref * 2.0e-2

--- a/test/test_from_array.py
+++ b/test/test_from_array.py
@@ -6,7 +6,7 @@ import pygalmesh
 
 def test_from_array():
 
-    n = 500
+    n = 200
     shape = (n, n, n)
     h = [1.0 / s for s in shape]
     vol = np.zeros(shape, dtype=np.uint16)

--- a/test/test_from_array.py
+++ b/test/test_from_array.py
@@ -1,0 +1,69 @@
+import os
+
+import helpers
+import pygalmesh
+
+import numpy as np
+
+
+def test_from_array():
+    
+    n = 500
+    shape = (n,n,n)
+    h     = [1./s for s in shape]
+    vol = np.zeros(shape, dtype=np.uint16)
+    i, j, k = np.arange(shape[0]), np.arange(shape[1]), np.arange(shape[2])
+    ii, jj, kk = np.meshgrid(i,j,k)
+    vol[ii*ii + jj*jj + kk*kk < n**2]        = 1
+    vol[ii*ii + jj*jj + kk*kk < (.5*n)**2]   = 2
+    
+    mesh = pygalmesh.generate_from_array(
+        vol, h, cell_size=100*min(h), facet_distance=min(h), verbose=False
+    )
+
+    tol = min(h)
+    ref = [1., 0., 1., 0., 1., 0.]
+    assert abs(max(mesh.points[:, 0]) - ref[0]) < tol 
+    assert abs(min(mesh.points[:, 0]) - ref[1]) < tol
+    assert abs(max(mesh.points[:, 1]) - ref[2]) < tol
+    assert abs(min(mesh.points[:, 1]) - ref[3]) < tol 
+    assert abs(max(mesh.points[:, 2]) - ref[4]) < tol
+    assert abs(min(mesh.points[:, 2]) - ref[5]) < tol
+
+    vol = sum(helpers.compute_volumes(mesh.points, mesh.get_cells_type("tetra")))
+    ref = 1./6.*np.pi
+    # Debian needs 2.0e-2 here.
+    # <https://github.com/nschloe/pygalmesh/issues/60>
+    assert abs(vol - ref) < ref * 2.0e-2
+    
+def test_from_array_with_subdomain_sizing():
+    
+    n = 500
+    shape = (n,n,n)
+    h     = [1./s for s in shape]
+    vol = np.zeros(shape, dtype=np.uint16)
+    i, j, k = np.arange(shape[0]), np.arange(shape[1]), np.arange(shape[2])
+    ii, jj, kk = np.meshgrid(i,j,k)
+    vol[ii*ii + jj*jj + kk*kk < n**2]        = 1
+    vol[ii*ii + jj*jj + kk*kk < (.5*n)**2]   = 2
+    
+    cell_sizes_map = {1: 100*min(h), 2: 10*min(h)}
+    
+    mesh = pygalmesh.generate_from_array_with_subdomain_sizing(
+        vol, h, cell_sizes_map=cell_sizes_map, facet_distance=min(h), verbose=False
+    )
+
+    tol = min(h)
+    ref = [1., 0., 1., 0., 1., 0.]
+    assert abs(max(mesh.points[:, 0]) - ref[0]) < tol 
+    assert abs(min(mesh.points[:, 0]) - ref[1]) < tol
+    assert abs(max(mesh.points[:, 1]) - ref[2]) < tol
+    assert abs(min(mesh.points[:, 1]) - ref[3]) < tol 
+    assert abs(max(mesh.points[:, 2]) - ref[4]) < tol
+    assert abs(min(mesh.points[:, 2]) - ref[5]) < tol
+
+    vol = sum(helpers.compute_volumes(mesh.points, mesh.get_cells_type("tetra")))
+    ref = 1./6.*np.pi
+    # Debian needs 2.0e-2 here.
+    # <https://github.com/nschloe/pygalmesh/issues/60>
+    assert abs(vol - ref) < ref * 2.0e-2

--- a/test/test_from_array.py
+++ b/test/test_from_array.py
@@ -37,7 +37,7 @@ def test_from_array():
 
 def test_from_array_with_subdomain_sizing():
 
-    n = 500
+    n = 200
     shape = (n, n, n)
     h = [1.0 / s for s in shape]
     vol = np.zeros(shape, dtype=np.uint16)


### PR DESCRIPTION
Add new functionalities inspired by `Iso2Mesh` `demo_vol2mesh_ex3.m`:

- `generate_from_inr_with_subdomain_sizing`: allows to specify a different `cell_size` for each subdomain of a  `inr` mesh (datatype: `uint8` or `uint16`).

- `generate_from_array`: generate a mesh from a 3D `numpy` array (either `uint` or `float`-type). This is done by saving the `numpy` array as `inr` image and then calling `generate_from_inr`.

- `generate_from_array_with_subdomain_sizing`: generate a mesh from a 3D `numpy` array (`uint`-type). This is done by saving the `numpy` array as `inr` image and then calling `generate_from_inrwith_subdomain_sizing`.

- `saveinr`: write a `numpy` array to `inr` mesh format. 