### PR TITLE
Do not force C++ standard library. Compiler will choose on it's own

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ ext_modules = [
             "src/version.cpp",
             "src/pybind11.cpp",
         ],
-        language="C++",
+        language="c++",
         include_dirs=[
             os.environ.get("EIGEN_INCLUDE_DIR", "/usr/include/eigen3/"),
             # Path to pybind11 headers
@@ -40,7 +40,7 @@ ext_modules = [
         ],
         extra_compile_args=["-std=c++14"],
         # no CGAL libraries necessary from CGAL 5.0 onwards
-        libraries=["stdc++", "gmp", "mpfr"],
+        libraries=["gmp", "mpfr"],
     )
 ]
 


### PR DESCRIPTION
This patch fixes the typo in setup.py to ensure that the correct driver
is used during linking. With this change, we don't need to specify the
C++ standard library and this also fixes the build with MSVC.