### PR TITLE
Feature reorient faces

### DIFF
--- a/pygalmesh/_cli/_volume_from_surface.py
+++ b/pygalmesh/_cli/_volume_from_surface.py
@@ -22,6 +22,7 @@ def volume_from_surface(argv=None):
         facet_distance=args.facet_distance,
         cell_radius_edge_ratio=args.cell_radius_edge_ratio,
         cell_size=args.cell_size,
+        reorient=args.reorient,
         verbose=not args.quiet,
     )
     meshio.write(args.outfile, mesh)
@@ -99,6 +100,14 @@ def _get_volume_from_surface_parser():
         type=float,
         default=0.0,
         help="cell radius/edge ratio (default: 0.0)",
+    )
+
+    parser.add_argument(
+        "--reorient",
+        "-t",
+        action="store_true",
+        default=False,
+        help="automatically fix face orientation (default: False)",
     )
 
     parser.add_argument(

--- a/pygalmesh/main.py
+++ b/pygalmesh/main.py
@@ -194,6 +194,7 @@ def generate_volume_mesh_from_surface_mesh(
     cell_radius_edge_ratio=0.0,
     cell_size=0.0,
     verbose=True,
+    reorient=True,
     seed=0,
 ):
     mesh = meshio.read(filename)
@@ -219,6 +220,7 @@ def generate_volume_mesh_from_surface_mesh(
         cell_radius_edge_ratio=cell_radius_edge_ratio,
         cell_size=cell_size,
         verbose=verbose,
+        reorient=reorient,
         seed=seed,
     )
 

--- a/pygalmesh/main.py
+++ b/pygalmesh/main.py
@@ -194,7 +194,7 @@ def generate_volume_mesh_from_surface_mesh(
     cell_radius_edge_ratio=0.0,
     cell_size=0.0,
     verbose=True,
-    reorient=True,
+    reorient=False,
     seed=0,
 ):
     mesh = meshio.read(filename)

--- a/src/generate_from_off.cpp
+++ b/src/generate_from_off.cpp
@@ -17,6 +17,8 @@
 #include <CGAL/Polygon_mesh_processing/orientation.h>
 #include <CGAL/IO/OFF_reader.h>
 
+// for sharp features
+//#include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 
 namespace pygalmesh {
 
@@ -24,6 +26,9 @@ namespace pygalmesh {
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Polyhedron_3<K> Polyhedron;
 typedef CGAL::Polyhedral_mesh_domain_3<Polyhedron, K> Mesh_domain;
+// for sharp features
+//typedef CGAL::Polyhedral_mesh_domain_with_features_3<K> Mesh_domain;
+//typedef CGAL::Mesh_polyhedron_3<K>::type Polyhedron;
 
 // Triangulation
 typedef CGAL::Mesh_triangulation_3<Mesh_domain>::type Tr;
@@ -74,7 +79,7 @@ void generate_from_off(
     CGAL::Polygon_mesh_processing::orient_polygon_soup(points, polygons);
     // create the polyhedron
     CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, polygons, polyhedron);
- 
+
   } else {
  
     // Create input polyhedron
@@ -91,12 +96,12 @@ void generate_from_off(
 
   input.close();
 
-  // NB: cgal has a check here to see if the input geometry is triangulated
-  // do we want it here?
-  // ...
-
   // Create domain
   Mesh_domain cgal_domain(polyhedron);
+
+  // Get sharp features
+  // cgal_domain.detect_features();
+
 
   // Mesh criteria
   Mesh_criteria criteria(

--- a/src/generate_from_off.cpp
+++ b/src/generate_from_off.cpp
@@ -59,6 +59,7 @@ void generate_from_off(
   Polyhedron polyhedron;
   // fix the orientation of the faces of the input file
   if (reorient) {
+    std::stringstream msg;
     msg << "fixing face orientation for \"" << infile <<"\""<< std::endl;
     std::vector<K::Point_3> points;
     std::vector<std::vector<std::size_t> > polygons;

--- a/src/generate_from_off.cpp
+++ b/src/generate_from_off.cpp
@@ -83,7 +83,7 @@ void generate_from_off(
       // <https://github.com/CGAL/cgal/issues/4632>
       std::stringstream msg;
       msg << "Invalid input file \"" << infile << "\"" << std::endl;
-      msg << "If this is due to wrong face orientation, retry with the option reorient=True \"" << std::endl;
+      msg << "If this is due to wrong face orientation, retry with the option --reorient \"" << std::endl;
       throw std::runtime_error(msg.str());
     }
   }

--- a/src/generate_from_off.hpp
+++ b/src/generate_from_off.hpp
@@ -21,6 +21,7 @@ generate_from_off(
     const double cell_radius_edge_ratio = 0.0,
     const double cell_size = 0.0,
     const bool verbose = true,
+    const bool reorient = true,
     const int seed = 0
     );
 

--- a/src/generate_from_off.hpp
+++ b/src/generate_from_off.hpp
@@ -21,7 +21,7 @@ generate_from_off(
     const double cell_radius_edge_ratio = 0.0,
     const double cell_size = 0.0,
     const bool verbose = true,
-    const bool reorient = true,
+    const bool reorient = false,
     const int seed = 0
     );
 

--- a/src/pybind11.cpp
+++ b/src/pybind11.cpp
@@ -339,6 +339,7 @@ PYBIND11_MODULE(_pygalmesh, m) {
         py::arg("cell_radius_edge_ratio") = 0.0,
         py::arg("cell_size") = 0.0,
         py::arg("verbose") = true,
+        py::arg("reorient") = true,
         py::arg("seed") = 0
         );
     m.def(

--- a/src/pybind11.cpp
+++ b/src/pybind11.cpp
@@ -339,7 +339,7 @@ PYBIND11_MODULE(_pygalmesh, m) {
         py::arg("cell_radius_edge_ratio") = 0.0,
         py::arg("cell_size") = 0.0,
         py::arg("verbose") = true,
-        py::arg("reorient") = true,
+        py::arg("reorient") = false,
         py::arg("seed") = 0
         );
     m.def(


### PR DESCRIPTION
Fix face orientation of input mesh. Default is false. use --reorient or -t to activate
  
how to test: remesh a surface and then create a volume mesh from this surface:
$ pygalmesh-remesh-surface lion-head.off lionhead_remesh.off -e 0.025 -a 25 -s 0.1 -d 0.001
$ pygalmesh-volume-from-surface lionhead_remesh.off lionhead_remesh_vol.vtu
RuntimeError: Invalid input file "/tmp/tmpnq6ln74_.off"
If this is due to wrong face orientation, retry with the option --reorient "
$ pygalmesh-volume-from-surface lionhead_remesh.off lionhead_remesh_vol.vtu --reorient
$