### PR TITLE
Correct signature of generate_from_array

### DIFF
--- a/pygalmesh/main.py
+++ b/pygalmesh/main.py
@@ -452,6 +452,8 @@ def generate_from_array(
     max_cell_circumradius: float | dict[int | str, float] = 0.0,
     max_facet_distance: float = 0.0,
     max_circumradius_edge_ratio: float = 0.0,
+    exude_time_limit: float = 0.0,
+    exude_sliver_bound: float = 0.0,
     verbose: bool = True,
     seed: int = 0,
 ):
@@ -471,6 +473,8 @@ def generate_from_array(
         max_facet_distance,
         max_circumradius_edge_ratio,
         max_cell_circumradius,
+        exude_time_limit,
+        exude_sliver_bound,
         verbose,
         seed,
     )


### PR DESCRIPTION
`generate_from_array` is missing parameters `exude_time_limit` and `exude_sliver_bound` from the list of input. This causes an error when calling `generate_from_inr` since arguments are called positionally an not by keyword.